### PR TITLE
Removes cap on `mdit-py-plugins` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = ["mdformat", "markdown", "formatter", "gfm"]
 python = "^3.7"
 mdformat = ">=0.7.5,<0.8.0"
 markdown-it-py = { version = "*", extras = [ "linkify" ] }  # Let `mdformat` choose version boundaries for `markdown-it-py`
-mdit-py-plugins = ">=0.2.0,<0.4.0"
+mdit-py-plugins = ">=0.2.0"
 mdformat-tables = ">=0.4.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Closes:
- https://github.com/hukkin/mdformat-gfm/issues/27

Addresses:
- https://github.com/KyleKing/mdformat-admon/issues/15