### PR TITLE
Replace linkify-it-py dependency with a GFM autolink plugin for markdown-it

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip install pre-commit mypy==1.11.2
         pre-commit run --all-files
-        mypy .
+        mypy src/ tests/
 
   pypi-publish:
     # Only publish if all other jobs succeed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.9"
 dependencies = [
     'mdformat >=0.7.5,<0.8.0',
-    'markdown-it-py[linkify]',  # Let `mdformat` choose version boundaries for `markdown-it-py`
+    'markdown-it-py',  # Let `mdformat` choose version boundaries for `markdown-it-py`
     'mdit-py-plugins >=0.2.0',
     'mdformat-tables >=0.4.0',
 ]
@@ -29,7 +29,7 @@ keywords = ["mdformat", "markdown", "formatter", "gfm"]
 "Homepage" = "https://github.com/hukkin/mdformat-gfm"
 
 [project.entry-points."mdformat.parser_extension"]
-"gfm" = "mdformat_gfm.plugin"
+"gfm" = "mdformat_gfm._mdformat_plugin"
 
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ deps = [
     "-r tests/requirements.txt",
     "mypy ==1.11.2",
 ]
-commands = [["mypy", { replace = "posargs", default = ["."], extend = true }]]
+commands = [["mypy", { replace = "posargs", default = ["src/", "tests/"], extend = true }]]
 
 
 [tool.isort]

--- a/src/mdformat_gfm/_gfm.py
+++ b/src/mdformat_gfm/_gfm.py
@@ -1,0 +1,6 @@
+# Whitespace characters, as specified in
+# https://github.github.com/gfm/#whitespace-character
+# (spec version 0.29-gfm (2019-04-06)
+WHITESPACE = frozenset(" \t\n\v\f\r")
+
+BEFORE_AUTOLINK_CHARS = WHITESPACE | {"*", "_", "~", "("}

--- a/src/mdformat_gfm/_mdformat_plugin.py
+++ b/src/mdformat_gfm/_mdformat_plugin.py
@@ -110,7 +110,7 @@ def _postprocess_inline(text: str, node: RenderTreeNode, context: RenderContext)
 
 
 def _gfm_autolink_renderer(node: RenderTreeNode, context: RenderContext) -> str:
-    return node.meta["source_autolink"]
+    return node.meta["source_text"]
 
 
 def _escape_text(text: str, node: RenderTreeNode, context: RenderContext) -> str:

--- a/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
+++ b/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
@@ -1,0 +1,216 @@
+import re
+
+from markdown_it import MarkdownIt
+from markdown_it.rules_inline import StateInline
+
+
+def gfm_autolink_plugin(md: MarkdownIt) -> None:
+    """Markdown-it plugin to parse GFM autolinks."""
+    md.inline.ruler.before("linkify", "gfm_autolink", gfm_autolink)
+    # "text" inline rule will skip "www." prefixed links, so needs to be
+    # disabled. This is probably disastrous for performance. An alternative, I think,
+    # would be to override the "text" inline rule with one that stops at a "."
+    # prefixed by "www".
+    md.inline.ruler.disable("text")
+
+
+# A string that matches this must still be invalidated if it ends with "_" or "-"
+RE_GFM_EMAIL = re.compile(r"[a-zA-Z0-9._+-]+@[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+")
+# A string that matches this must still be invalidated if last two segments contain "_"
+RE_GFM_AUTOLINK_DOMAIN = re.compile(r"[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+")
+
+RE_ENDS_IN_ENTITY_REF = re.compile(r"&[a-zA-Z0-9]+;\Z")
+
+# Whitespace characters, as specified in
+# https://github.github.com/gfm/#whitespace-character
+# (spec version 0.29-gfm (2019-04-06)
+GFM_WHITESPACE = frozenset(" \t\n\v\f\r")
+
+ASCII_ALPHANUMERICS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "0123456789"
+)
+
+
+def gfm_autolink(state: StateInline, silent: bool) -> bool:  # noqa: C901
+    """Markdown-it-py rule to parse GFM autolinks.
+
+    This parser autolinks as specified here:
+    https://github.github.com/gfm/#autolinks-extension-
+
+    Args:
+        state: Parse state object.
+        silent: Disables token generation.
+    Returns:
+        bool: True if GFM autolink found.
+    """
+    pos = state.pos
+    src = state.src
+
+    # Autolink can only be at the beginning of a line, after whitespace,
+    # or any of the delimiting characters *, _, ~, and (.
+    if pos:
+        preceding_char = src[pos - 1]
+        if preceding_char not in GFM_WHITESPACE | {"*", "_", "~", "("}:
+            return False
+
+    if src.startswith("www.", pos):
+        pos += 4
+        try:
+            pos, domain, resource = read_domain_and_resource(src, pos)
+        except NotFound:
+            return False
+
+        url = f"www.{domain}{resource}"
+        full_url = "http://" + url
+    elif src.startswith(("http://", "https://"), pos):
+        scheme = "https://" if src[pos + 4] == "s" else "http://"
+        pos += len(scheme)
+
+        try:
+            pos, domain, resource = read_domain_and_resource(src, pos)
+        except NotFound:
+            return False
+
+        url = f"{scheme}{domain}{resource}"
+        full_url = url
+    elif src.startswith(("mailto:", "xmpp:"), pos):
+        scheme = "xmpp:" if src[pos] == "x" else "mailto:"
+        pos += len(scheme)
+
+        try:
+            pos, email = read_email(src, pos)
+        except NotFound:
+            return False
+
+        if scheme == "xmpp:" and src[pos : pos + 1] == "/":
+            pos += 1
+            resource_start_pos = pos
+            while pos < len(src) and src[pos] in ASCII_ALPHANUMERICS | {".", "@"}:
+                pos += 1
+            resource = src[resource_start_pos:pos]
+            if resource.endswith("."):
+                pos -= 1
+                resource = resource[:-1]
+            if not resource:
+                return False
+        else:
+            resource = ""
+
+        source_autolink = scheme + email
+        if resource:
+            source_autolink += "/" + resource
+
+        url = source_autolink
+        full_url = source_autolink
+    else:
+        try:
+            pos, email = read_email(src, pos)
+        except NotFound:
+            return False
+
+        url = email
+        full_url = "mailto:" + email
+
+    normalized_full_url = state.md.normalizeLink(full_url)
+    if not state.md.validateLink(normalized_full_url):
+        return False
+
+    push_tokens(state, normalized_full_url, url, silent)
+    state.pos = pos
+    return True
+
+
+def push_tokens(
+    state: StateInline, full_url: str, source_url: str, silent: bool
+) -> None:
+    if silent:
+        return
+    token = state.push("gfm_autolink_open", "a", 1)
+    token.attrs = {"href": full_url}
+    token.meta = {"source_autolink": source_url}
+
+    token = state.push("text", "", 0)
+    token.content = state.md.normalizeLinkText(source_url)
+
+    state.push("gfm_autolink_close", "a", -1)
+
+
+def trim_resource(untrimmed: str) -> tuple[str, int]:
+    """Trim illegal trailing chars from autolink resource.
+
+    Trim trailing punctuation, parentheses and entity refs as per GFM
+    spec. Also trim backslashes. The spec does not mention backslash,
+    but I think it should. This is referred to as "extended autolink
+    path validation" in the GFM spec. Return a tuple with the trimmed
+    resource and the amount of characters removed.
+    """
+    i = len(untrimmed) - 1
+    while i >= 0:
+        c = untrimmed[i]
+        if c == ";":
+            ending_entity_match = RE_ENDS_IN_ENTITY_REF.search(untrimmed, endpos=i + 1)
+            if not ending_entity_match:
+                break
+            i = ending_entity_match.start()
+        elif c == ")":
+            if untrimmed.count("(", 0, i + 1) >= untrimmed.count(")", 0, i + 1):
+                break
+        elif c in {"?", "!", ".", ",", ":", "*", "_", "~"}:
+            pass
+        elif c == "\\":  # not part of the spec, but should be
+            pass
+        else:
+            break
+        i -= 1
+
+    trimmed = untrimmed[: i + 1]
+    trim_count = len(untrimmed) - len(trimmed)
+    return trimmed, trim_count
+
+
+class NotFound(Exception):
+    """Raised if a function didn't find what it was looking for."""
+
+
+def read_domain_and_resource(src: str, pos: int) -> tuple[int, str, str]:
+    """Read autolink domain and resource.
+
+    Raise NotFound if not found. Return a tuple (pos, domain, resource).
+    """
+    domain_match = RE_GFM_AUTOLINK_DOMAIN.match(src, pos)
+    if not domain_match:
+        raise NotFound
+    domain = domain_match.group()
+    pos = domain_match.end()
+    segments = domain.rsplit(".", 2)
+    if "_" in segments[-2] or "_" in segments[-1]:
+        raise NotFound
+
+    resource_start_pos = pos
+    while pos < len(src) and src[pos] not in GFM_WHITESPACE | {"<"}:
+        pos += 1
+    resource = src[resource_start_pos:pos]
+
+    resource, trim_count = trim_resource(resource)
+    pos -= trim_count
+    return pos, domain, resource
+
+
+def read_email(src: str, pos: int) -> tuple[int, str]:
+    """Read autolink email.
+
+    Raise NotFound if not found. Return a tuple (pos, email).
+    """
+    email_match = RE_GFM_EMAIL.match(src, pos)
+    email = email_match.group() if email_match else None
+    if not email or email[-1] in {"-", "_"}:
+        raise NotFound
+    pos = email_match.end()
+
+    # This isn't really part of the GFM spec, but an attempt to cover
+    # up its flaws. If a trailing hyphen or underscore invalidates an
+    # autolink, then an escaped hyphen or underscore should too.
+    if src[pos : pos + 2] in {"\\-", "\\_"}:
+        raise NotFound
+
+    return pos, email

--- a/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
+++ b/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
@@ -205,6 +205,7 @@ def read_email(src: str, pos: int) -> tuple[int, str]:
     email = email_match.group() if email_match else None
     if not email or email[-1] in {"-", "_"}:
         raise NotFound
+    assert email_match is not None
     pos = email_match.end()
 
     # This isn't really part of the GFM spec, but an attempt to cover

--- a/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
+++ b/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
@@ -3,6 +3,7 @@ import re
 from markdown_it import MarkdownIt
 from markdown_it.rules_inline import StateInline
 
+from mdformat_gfm import _gfm
 from mdformat_gfm._text_inline_rule import text_rule
 
 
@@ -23,11 +24,6 @@ RE_GFM_EMAIL = re.compile(r"[a-zA-Z0-9._+-]+@[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+
 RE_GFM_AUTOLINK_DOMAIN = re.compile(r"[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)+")
 
 RE_ENDS_IN_ENTITY_REF = re.compile(r"&[a-zA-Z0-9]+;\Z")
-
-# Whitespace characters, as specified in
-# https://github.github.com/gfm/#whitespace-character
-# (spec version 0.29-gfm (2019-04-06)
-GFM_WHITESPACE = frozenset(" \t\n\v\f\r")
 
 ASCII_ALPHANUMERICS = frozenset(
     "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "0123456789"
@@ -53,7 +49,7 @@ def gfm_autolink(state: StateInline, silent: bool) -> bool:  # noqa: C901
     # or any of the delimiting characters *, _, ~, and (.
     if pos:
         preceding_char = src[pos - 1]
-        if preceding_char not in GFM_WHITESPACE | {"*", "_", "~", "("}:
+        if preceding_char not in _gfm.BEFORE_AUTOLINK_CHARS:
             return False
 
     if src.startswith("www.", pos):
@@ -190,7 +186,7 @@ def read_domain_and_resource(src: str, pos: int) -> tuple[int, str, str]:
         raise NotFound
 
     resource_start_pos = pos
-    while pos < len(src) and src[pos] not in GFM_WHITESPACE | {"<"}:
+    while pos < len(src) and src[pos] not in _gfm.WHITESPACE | {"<"}:
         pos += 1
     resource = src[resource_start_pos:pos]
 

--- a/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
+++ b/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
@@ -130,7 +130,7 @@ def push_tokens(
         return
     token = state.push("gfm_autolink_open", "a", 1)
     token.attrs = {"href": full_url}
-    token.meta = {"source_autolink": source_url}
+    token.meta = {"source_text": source_url}
 
     token = state.push("text", "", 0)
     token.content = state.md.normalizeLinkText(source_url)

--- a/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
+++ b/src/mdformat_gfm/_mdit_gfm_autolink_plugin.py
@@ -3,15 +3,18 @@ import re
 from markdown_it import MarkdownIt
 from markdown_it.rules_inline import StateInline
 
+from mdformat_gfm._text_inline_rule import text_rule
+
 
 def gfm_autolink_plugin(md: MarkdownIt) -> None:
     """Markdown-it plugin to parse GFM autolinks."""
     md.inline.ruler.before("linkify", "gfm_autolink", gfm_autolink)
-    # "text" inline rule will skip "www." prefixed links, so needs to be
-    # disabled. This is probably disastrous for performance. An alternative, I think,
-    # would be to override the "text" inline rule with one that stops at a "."
-    # prefixed by "www".
-    md.inline.ruler.disable("text")
+
+    # The default "text" inline rule will skip starting characters of GFM
+    # autolinks. It can be disabled, but that is disastrous for performance.
+    # Instead, we replace it with a custom "text" inline rule that yields at
+    # locations that can potentially be the beginning of a GFM autolink.
+    md.inline.ruler.at("text", text_rule)
 
 
 # A string that matches this must still be invalidated if it ends with "_" or "-"

--- a/src/mdformat_gfm/_text_inline_rule.py
+++ b/src/mdformat_gfm/_text_inline_rule.py
@@ -1,0 +1,87 @@
+"""A replacement for the "text" inline rule in markdown-it.
+
+The default "text" rule will skip until the next character in
+`_TerminatorChars` is found. This extends the set of termination points
+to those that can potentially be the beginning of a GFM autolink. The
+GFM autolink plugin also works with "text" inline rule disabled, but
+this should (at least partially) bring back the performance boost that
+"text" inline rule provides.
+"""
+
+import re
+
+from markdown_it.rules_inline import StateInline
+
+GFM_WHITESPACE = frozenset(" \t\n\v\f\r")
+BEFORE_VALID_AUTOLINK_CHARS = GFM_WHITESPACE | {"*", "_", "~", "("}
+
+# The default set of terminator characters
+_TerminatorChars = {
+    "\n",
+    "!",
+    "#",
+    "$",
+    "%",
+    "&",
+    "*",
+    "+",
+    "-",
+    ":",
+    "<",
+    "=",
+    ">",
+    "@",
+    "[",
+    "\\",
+    "]",
+    "^",
+    "_",
+    "`",
+    "{",
+    "}",
+    "~",
+}
+
+_default_terminator = "[" + re.escape("".join(_TerminatorChars)) + "]"
+_gfm_autolink_terminator = (
+    r"(?:" r"www\." "|" "http" "|" "mailto:" "|" "xmpp:" "|" r"[a-zA-Z0-9._+-]+@" r")"
+)
+_before_autolink_terminator = (
+    "[" + re.escape("".join(BEFORE_VALID_AUTOLINK_CHARS)) + "]"
+)
+
+_RE_TERMINATOR_FIRST_CHAR = re.compile(
+    _default_terminator + "|" + _gfm_autolink_terminator
+)
+_RE_TERMINATOR_NON_FIRST_CHAR = re.compile(
+    r"(?s:.)"  # match any character (also newline)
+    + _default_terminator
+    + "|"
+    + _before_autolink_terminator
+    + _gfm_autolink_terminator
+)
+
+
+def text_rule(state: StateInline, silent: bool) -> bool:
+    pos = state.pos
+
+    if not pos:
+        if _RE_TERMINATOR_FIRST_CHAR.match(state.src):
+            return False
+        pos += 1
+
+    terminator_match = _RE_TERMINATOR_NON_FIRST_CHAR.search(state.src, pos - 1)
+    if terminator_match:
+        pos = terminator_match.start() + 1
+    else:
+        pos = state.posMax
+
+    if pos == state.pos:
+        return False
+
+    if not silent:
+        state.pending += state.src[state.pos : pos]
+
+    state.pos = pos
+
+    return True

--- a/src/mdformat_gfm/_text_inline_rule.py
+++ b/src/mdformat_gfm/_text_inline_rule.py
@@ -12,8 +12,7 @@ import re
 
 from markdown_it.rules_inline import StateInline
 
-GFM_WHITESPACE = frozenset(" \t\n\v\f\r")
-BEFORE_AUTOLINK_CHARS = GFM_WHITESPACE | {"*", "_", "~", "("}
+from mdformat_gfm import _gfm
 
 # The default set of terminator characters
 _TerminatorChars = {
@@ -46,7 +45,7 @@ _default_terminator = "[" + re.escape("".join(_TerminatorChars)) + "]"
 _gfm_autolink_terminator = (
     r"(?:" r"www\." "|" "http" "|" "mailto:" "|" "xmpp:" "|" r"[a-zA-Z0-9._+-]+@" r")"
 )
-_before_autolink = "[" + re.escape("".join(BEFORE_AUTOLINK_CHARS)) + "]"
+_before_autolink = "[" + re.escape("".join(_gfm.BEFORE_AUTOLINK_CHARS)) + "]"
 
 _RE_TERMINATOR_FIRST_CHAR = re.compile(
     _default_terminator + "|" + _gfm_autolink_terminator
@@ -63,11 +62,14 @@ _RE_TERMINATOR_NON_FIRST_CHAR = re.compile(
 def text_rule(state: StateInline, silent: bool) -> bool:
     pos = state.pos
 
+    # Handle the special case where `pos` is zero
     if not pos:
         if _RE_TERMINATOR_FIRST_CHAR.match(state.src):
             return False
-        pos += 1
+        pos = 1
 
+    # Now `pos` cannot be zero, so we can search with a regex that looks at
+    # preceding character too.
     terminator_match = _RE_TERMINATOR_NON_FIRST_CHAR.search(state.src, pos - 1)
     if terminator_match:
         pos = terminator_match.start() + 1

--- a/src/mdformat_gfm/_text_inline_rule.py
+++ b/src/mdformat_gfm/_text_inline_rule.py
@@ -13,7 +13,7 @@ import re
 from markdown_it.rules_inline import StateInline
 
 GFM_WHITESPACE = frozenset(" \t\n\v\f\r")
-BEFORE_VALID_AUTOLINK_CHARS = GFM_WHITESPACE | {"*", "_", "~", "("}
+BEFORE_AUTOLINK_CHARS = GFM_WHITESPACE | {"*", "_", "~", "("}
 
 # The default set of terminator characters
 _TerminatorChars = {
@@ -46,9 +46,7 @@ _default_terminator = "[" + re.escape("".join(_TerminatorChars)) + "]"
 _gfm_autolink_terminator = (
     r"(?:" r"www\." "|" "http" "|" "mailto:" "|" "xmpp:" "|" r"[a-zA-Z0-9._+-]+@" r")"
 )
-_before_autolink_terminator = (
-    "[" + re.escape("".join(BEFORE_VALID_AUTOLINK_CHARS)) + "]"
-)
+_before_autolink = "[" + re.escape("".join(BEFORE_AUTOLINK_CHARS)) + "]"
 
 _RE_TERMINATOR_FIRST_CHAR = re.compile(
     _default_terminator + "|" + _gfm_autolink_terminator
@@ -57,7 +55,7 @@ _RE_TERMINATOR_NON_FIRST_CHAR = re.compile(
     r"(?s:.)"  # match any character (also newline)
     + _default_terminator
     + "|"
-    + _before_autolink_terminator
+    + _before_autolink
     + _gfm_autolink_terminator
 )
 

--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -62,7 +62,7 @@ Autolink with a backslash
 .
 http://www.python.org/autolink\extension
 .
-http://www.python.org/autolink%5Cextension
+http://www.python.org/autolink\extension
 .
 
 Autolink with percentage encoded space

--- a/tests/data/gfm_autolink.md
+++ b/tests/data/gfm_autolink.md
@@ -1,0 +1,264 @@
+linkify
+.
+url http://www.youtube.com/watch?v=5Jt5GEr4AYg.
+.
+<p>url <a href="http://www.youtube.com/watch?v=5Jt5GEr4AYg">http://www.youtube.com/watch?v=5Jt5GEr4AYg</a>.</p>
+.
+
+
+don't touch text in links
+.
+[https://example.com](https://example.com)
+.
+<p><a href="https://example.com">https://example.com</a></p>
+.
+
+
+don't touch text in autolinks
+.
+<https://example.com>
+.
+<p><a href="https://example.com">https://example.com</a></p>
+.
+
+
+don't touch text in html <a> tags
+.
+<a href="https://example.com">https://example.com</a>
+.
+<p><a href="https://example.com">https://example.com</a></p>
+.
+
+entities inside raw links
+.
+https://example.com/foo&amp;bar
+.
+<p><a href="https://example.com/foo&amp;amp;bar">https://example.com/foo&amp;amp;bar</a></p>
+.
+
+
+emphasis inside raw links (asterisk, can happen in links with params)
+.
+https://example.com/foo*bar*baz
+.
+<p><a href="https://example.com/foo*bar*baz">https://example.com/foo*bar*baz</a></p>
+.
+
+
+emphasis inside raw links (underscore)
+.
+http://example.org/foo._bar_-_baz
+.
+<p><a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a></p>
+.
+
+
+backticks inside raw links
+.
+https://example.com/foo`bar`baz
+.
+<p><a href="https://example.com/foo%60bar%60baz">https://example.com/foo`bar`baz</a></p>
+.
+
+
+links inside raw links
+.
+https://example.com/foo[123](456)bar
+.
+<p><a href="https://example.com/foo%5B123%5D(456)bar">https://example.com/foo[123](456)bar</a></p>
+.
+
+escaped CommonMark autolink
+.
+\<https://python.org>
+.
+<p>&lt;https://python.org&gt;</p>
+.
+
+escapes not allowed at the start
+.
+\https://example.com
+.
+<p>\https://example.com</p>
+.
+
+
+escapes not allowed at comma
+.
+https\://example.com
+.
+<p>https://example.com</p>
+.
+
+
+escapes not allowed at slashes
+.
+https:\//aa.org https://bb.org
+.
+<p>https://aa.org <a href="https://bb.org">https://bb.org</a></p>
+.
+
+
+fuzzy link shouldn't match cc.org
+.
+https:/\/cc.org
+.
+<p>https://cc.org</p>
+.
+
+
+bold links (exclude markup of pairs from link tail)
+.
+**http://example.com/foobar**
+.
+<p><strong><a href="http://example.com/foobar">http://example.com/foobar</a></strong></p>
+.
+
+match links without protocol
+.
+www.example.org
+.
+<p><a href="http://www.example.org">www.example.org</a></p>
+.
+
+match links without protocol, part 2
+.
+GFM autolink www.commonmark.org
+.
+<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>
+.
+
+coverage, prefix not valid
+.
+http:/example.com/
+.
+<p>http:/example.com/</p>
+.
+
+
+coverage, negative link level
+.
+</a>[https://example.com](https://example.com)
+.
+<p></a><a href="https://example.com">https://example.com</a></p>
+.
+
+
+emphasis with '*', real link:
+.
+http://cdecl.ridiculousfish.com/?q=int+%28*f%29+%28float+*%29%3B
+.
+<p><a href="http://cdecl.ridiculousfish.com/?q=int+%28*f%29+%28float+*%29%3B">http://cdecl.ridiculousfish.com/?q=int+(*f)+(float+*)%3B</a></p>
+.
+
+emphasis with '_', real link:
+.
+https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf
+.
+<p><a href="https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf">https://www.sell.fi/sites/default/files/elainlaakarilehti/tieteelliset_artikkelit/kahkonen_t._et_al.canine_pancreatitis-_review.pdf</a></p>
+.
+
+emails
+.
+test@example.com
+
+mailto:test@example.com
+
+xmpp:foo@bar.baz/blaa@flii.buu.
+.
+<p><a href="mailto:test@example.com">test@example.com</a></p>
+<p><a href="mailto:test@example.com">mailto:test@example.com</a></p>
+<p><a href="xmpp:foo@bar.baz/blaa@flii.buu">xmpp:foo@bar.baz/blaa@flii.buu</a>.</p>
+.
+
+
+typorgapher should not break href
+.
+http://example.com/(c)
+.
+<p><a href="http://example.com/(c)">http://example.com/(c)</a></p>
+.
+
+before line
+.
+before
+www.github.com
+.
+<p>before
+<a href="http://www.github.com">www.github.com</a></p>
+.
+
+after line
+.
+github.com
+after
+.
+<p>github.com
+after</p>
+.
+
+before after lines
+.
+before
+github.com
+after
+.
+<p>before
+github.com
+after</p>
+.
+
+before after lines with blank line
+.
+before
+
+github.com
+
+after
+.
+<p>before</p>
+<p>github.com</p>
+<p>after</p>
+.
+
+Don't match escaped
+.
+google\.com
+.
+<p>google.com</p>
+.
+
+Issue [#300](https://github.com/executablebooks/markdown-it-py/issues/300) emphasis inside raw links (underscore) at beginning of line
+.
+http://example.org/foo._bar_-_baz This works
+.
+<p><a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a> This works</p>
+.
+
+Issue [#300](https://github.com/executablebooks/markdown-it-py/issues/300) emphasis inside raw links (underscore) at end of line
+.
+This doesnt http://example.org/foo._bar_-_baz
+.
+<p>This doesnt <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a></p>
+.
+
+Issue [#300](https://github.com/executablebooks/markdown-it-py/issues/300) emphasis inside raw links (underscore) mix1
+.
+While this `does` http://example.org/foo._bar_-_baz, this doesnt http://example.org/foo._bar_-_baz and this **does** http://example.org/foo._bar_-_baz
+.
+<p>While this <code>does</code> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a>, this doesnt <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a> and this <strong>does</strong> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a></p>
+.
+
+Issue [#300](https://github.com/executablebooks/markdown-it-py/issues/300) emphasis inside raw links (underscore) mix2
+.
+This applies to _series of URLs too_ http://example.org/foo._bar_-_baz http://example.org/foo._bar_-_baz, these dont http://example.org/foo._bar_-_baz http://example.org/foo._bar_-_baz and these **do** http://example.org/foo._bar_-_baz http://example.org/foo._bar_-_baz
+.
+<p>This applies to <em>series of URLs too</em> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a>, these dont <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a> and these <strong>do</strong> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a> <a href="http://example.org/foo._bar_-_baz">http://example.org/foo._bar_-_baz</a></p>
+.
+
+emphasis inside raw links (asterisk) at end of line
+.
+This doesnt http://example.org/foo.*bar*-*baz
+.
+<p>This doesnt <a href="http://example.org/foo.*bar*-*baz">http://example.org/foo.*bar*-*baz</a></p>
+.

--- a/tests/test_markdown_it_plugin.py
+++ b/tests/test_markdown_it_plugin.py
@@ -2,9 +2,13 @@ from markdown_it import MarkdownIt
 
 from mdformat_gfm._mdit_gfm_autolink_plugin import gfm_autolink_plugin
 
+
 def test_gfm_autolink():
     mdit = MarkdownIt()
     mdit.use(gfm_autolink_plugin)
     text = "GFM autolink www.commonmark.org"
     html = mdit.render(text)
-    assert html == '<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>\n'
+    assert (
+        html
+        == '<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>\n'
+    )

--- a/tests/test_markdown_it_plugin.py
+++ b/tests/test_markdown_it_plugin.py
@@ -1,14 +1,16 @@
+from pathlib import Path
+
 from markdown_it import MarkdownIt
+from markdown_it.utils import read_fixture_file
+import pytest
 
 from mdformat_gfm._mdit_gfm_autolink_plugin import gfm_autolink_plugin
 
+FIXTURE_PATH = Path(__file__).parent / "data" / "gfm_autolink.md"
 
-def test_gfm_autolink():
-    mdit = MarkdownIt()
-    mdit.use(gfm_autolink_plugin)
-    text = "GFM autolink www.commonmark.org"
-    html = mdit.render(text)
-    assert (
-        html
-        == '<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>\n'  # noqa: E501
-    )
+
+@pytest.mark.parametrize("line,title,md,expected_html", read_fixture_file(FIXTURE_PATH))
+def test_gfm_autolink(line, title, md, expected_html):
+    mdit = MarkdownIt().use(gfm_autolink_plugin)
+    text = mdit.render(md)
+    assert text.rstrip() == expected_html.rstrip()

--- a/tests/test_markdown_it_plugin.py
+++ b/tests/test_markdown_it_plugin.py
@@ -1,0 +1,10 @@
+from markdown_it import MarkdownIt
+
+from mdformat_gfm._mdit_gfm_autolink_plugin import gfm_autolink_plugin
+
+def test_gfm_autolink():
+    mdit = MarkdownIt()
+    mdit.use(gfm_autolink_plugin)
+    text = "GFM autolink www.commonmark.org"
+    html = mdit.render(text)
+    assert html == '<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>\n'

--- a/tests/test_markdown_it_plugin.py
+++ b/tests/test_markdown_it_plugin.py
@@ -10,5 +10,5 @@ def test_gfm_autolink():
     html = mdit.render(text)
     assert (
         html
-        == '<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>\n'
+        == '<p>GFM autolink <a href="http://www.commonmark.org">www.commonmark.org</a></p>\n'  # noqa: E501
     )


### PR DESCRIPTION
Closes https://github.com/hukkin/mdformat-gfm/issues/47

Needs tests.